### PR TITLE
manage issues with libcurl3 missing from recent editions of ubuntu

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,10 @@ FILE "_____ ___ _______.bin" BINARY
 ```bash
 sudo rm /usr/share/applications/ePSXe.desktop
 ```
+If you are running Ubuntu 18.04 or later:
+```bash
+sudo rm /usr/lib/x86_64-linux-gnu/libcurl.so.3
+```
 
 <p align="center"><strong>SUDO</strong> password required</p>
 

--- a/ePSXe64Ubuntu.sh
+++ b/ePSXe64Ubuntu.sh
@@ -30,7 +30,7 @@ if (( $(echo $(. /etc/os-release ; echo $VERSION_ID) '< 18.04'|bc -l) ))
 then
 	sudo apt -y install libcurl3 libsdl-ttf2.0-0 libssl1.0.0 ecm unzip
 else
-	sudo apt -y install libsdl-ttf2.0-0 libssl1.0.0 ecm unzip
+	sudo apt -y install libncurses5 libsdl-ttf2.0-0 libssl1.0.0 ecm unzip
 	wget http://archive.ubuntu.com/ubuntu/pool/main/c/curl3/libcurl3_7.58.0-2ubuntu2_amd64.deb -O /tmp/libcurl3_7.58.0-2ubuntu2_amd64.deb
 	sudo mkdir /tmp/libcurl3
 	sudo dpkg-deb -x /tmp/libcurl3_7.58.0-2ubuntu2_amd64.deb /tmp/libcurl3

--- a/ePSXe64Ubuntu.sh
+++ b/ePSXe64Ubuntu.sh
@@ -32,7 +32,7 @@ then
 	wget http://archive.ubuntu.com/ubuntu/pool/main/c/curl3/libcurl3_7.58.0-2ubuntu2_amd64.deb -O /tmp/libcurl3_7.58.0-2ubuntu2_amd64.deb
 	sudo mkdir /tmp/libcurl3
 	sudo dpkg-deb -x /tmp/libcurl3_7.58.0-2ubuntu2_amd64.deb /tmp/libcurl3
-	sudo cp -iv /tmp/libcurl3/usr/lib/x86_64-linux-gnu/libcurl.so.4.5.0 /usr/lib/x86_64-linux-gnu/libcurl.so.3
+	sudo cp -vn /tmp/libcurl3/usr/lib/x86_64-linux-gnu/libcurl.so.4.5.0 /usr/lib/x86_64-linux-gnu/libcurl.so.3
 	sudo rm -rf /tmp/libcurl3
 	rm -rf /tmp/libcurl3_7.58.0-2ubuntu2_amd64.deb
 else
@@ -75,12 +75,17 @@ fi
 	if [ "$(. /etc/os-release ; echo $ID)" == "ubuntu" ] && [ "$(echo $(. /etc/os-release ; echo $VERSION_ID)|cut -c -2)" -ge 18 ]
 	then
 	  xxd /tmp/epsxe_x64 /tmp/epsxe_x64.xxd
-	  rm -f /tmp/epsxe_x64
 	  patch /tmp/epsxe_x64.xxd <(echo "6434c
 00019210: 2e73 6f2e 3300 6375 726c 5f65 6173 795f  .so.3.curl_easy_
 .")
 	  xxd -r /tmp/epsxe_x64.xxd "/home/$USER/ePSXe"
 	  rm -f /tmp/epsxe_x64.xxd
+	  if ! sha256sum -c --quiet <(echo "45fb1ee4cb21a5591de64e1a666e4c3cacb30fcc308f0324dc5b2b57767e18ee  /home/$USER/ePSXe")
+	  then
+	    tput setaf 1; echo "WARNING: patched /home/$USER/ePSXe did not match checksum, using original executable instead"; tput sgr0
+	    cp -f /tmp/epsxe_x64 "/home/$USER/ePSXe"
+	  fi
+	  rm -f /tmp/epsxe_x64
 	else
 	  mv "/tmp/epsxe_x64" "/home/$USER/ePSXe"
 	fi

--- a/ePSXe64Ubuntu.sh
+++ b/ePSXe64Ubuntu.sh
@@ -26,10 +26,8 @@ tput setaf 1; echo "  CLOSE ePSXe GUI to continue with the script."; tput sgr0
 tput setaf 2; echo "Script started."; tput sgr0
 
 # Installs required packages per OS
-if (( $(echo $(. /etc/os-release ; echo $VERSION_ID) '< 18.04'|bc -l) ))
+if [ "$(. /etc/os-release ; echo $ID)" == "ubuntu" ] && [ "$(echo $(. /etc/os-release ; echo $VERSION_ID)|cut -c -2)" -ge 18 ]
 then
-	sudo apt -y install libcurl3 libsdl-ttf2.0-0 libssl1.0.0 ecm unzip
-else
 	sudo apt -y install libncurses5 libsdl-ttf2.0-0 libssl1.0.0 ecm unzip
 	wget http://archive.ubuntu.com/ubuntu/pool/main/c/curl3/libcurl3_7.58.0-2ubuntu2_amd64.deb -O /tmp/libcurl3_7.58.0-2ubuntu2_amd64.deb
 	sudo mkdir /tmp/libcurl3
@@ -37,6 +35,8 @@ else
 	sudo cp -iv /tmp/libcurl3/usr/lib/x86_64-linux-gnu/libcurl.so.4.5.0 /usr/lib/x86_64-linux-gnu/libcurl.so.3
 	sudo rm -rf /tmp/libcurl3
 	rm -rf /tmp/libcurl3_7.58.0-2ubuntu2_amd64.deb
+else
+	sudo apt -y install libcurl3 libsdl-ttf2.0-0 libssl1.0.0 ecm unzip
 fi
 
 # Back-up function
@@ -72,18 +72,17 @@ fi
 # Sets up ePSXe
 	wget -q "http://www.epsxe.com/files/$ins" -P "/tmp"
 	unzip -qq "/tmp/$ins" -d "/tmp"
-	if (( $(echo $(. /etc/os-release ; echo $VERSION_ID) '< 18.04'|bc -l) ))
+	if [ "$(. /etc/os-release ; echo $ID)" == "ubuntu" ] && [ "$(echo $(. /etc/os-release ; echo $VERSION_ID)|cut -c -2)" -ge 18 ]
 	then
-	  mv "/tmp/epsxe_x64" "/home/$USER/ePSXe"
-	else
 	  xxd /tmp/epsxe_x64 /tmp/epsxe_x64.xxd
 	  rm -f /tmp/epsxe_x64
-	  echo "6434c
+	  patch /tmp/epsxe_x64.xxd <(echo "6434c
 00019210: 2e73 6f2e 3300 6375 726c 5f65 6173 795f  .so.3.curl_easy_
-.
-wq"|ed /tmp/epsxe_x64.xxd >/dev/null
+.")
 	  xxd -r /tmp/epsxe_x64.xxd "/home/$USER/ePSXe"
 	  rm -f /tmp/epsxe_x64.xxd
+	else
+	  mv "/tmp/epsxe_x64" "/home/$USER/ePSXe"
 	fi
 	chmod +x "/home/$USER/ePSXe"
 	"/home/$USER/ePSXe"


### PR DESCRIPTION
This fixes the problem where recent versions of ubuntu can't have libcurl3 installed at the same time as libcurl4 or in the case of 18.10, it's not available at all.  It does this by downloading the 18.04 version of libcurl3 and installing it with the name libcurl.so.3 instead of libcurl.so.4.  It then patches the ePSXe executable to look for libcurl.so.3 instead of libcurl.so.4.

I haven't tried running any games with it yet, but it starts the program.  Hopefully I can do some testing later.  It's the best solution I can think of to get ePSXe working on ubuntu 18.04/18.10 alongside libcurl4.

It shows the output of many of the things it does instead of hides it, I don't know if you care.  I would personally prefer to see the output of apt at least.  It also asks permission to overwrite libcurl.so.3 if it already exists so we don't accidentally screw anyone's system.